### PR TITLE
fix image loading in static build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,8 +15,9 @@ const config = {
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
   reactStrictMode: true,
   images: {
-    domains: ['a.ppy.sh']
-  }
+    loader: 'custom',
+    loaderFile: './utils/ppyImageLoader.ts',
+  },
 };
 
 export default withMDX(config);

--- a/utils/ppyImageLoader.ts
+++ b/utils/ppyImageLoader.ts
@@ -1,0 +1,6 @@
+export default function absoluteUriImageLoader({ src }: {src: string}): string {
+  /**
+   * @param src full URI to remote image (including all of: scheme://host/uri?query_params)
+   */
+  return src
+}


### PR DESCRIPTION
Previously, Image components would load images through `/_next/image/?url=<full_remote_url>` which does not work once the site has been built into a static SPA. 

This PR implements a custom image loader that does nothing. It does nothing, and expects to have a `src` parameter containing the full remote path.

I have no idea what I'm doing.